### PR TITLE
Added support for cl-syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: common-lisp
 
 env:
   matrix:
-    - LISP=allegro
     - LISP=sbcl
     - LISP=ccl
     - LISP=clisp

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - LISP=ccl
     - LISP=clisp
     - LISP=ecl
+    - LISP=abcl
 
 install:
   - if [ -x ./install.sh ] && head -2 ./install.sh | grep '^# cl-travis' > /dev/null;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: common-lisp
+
+env:
+  matrix:
+    - LISP=allego
+    - LISP=sbcl
+    - LISP=ccl
+    - LISP=clisp
+    - LISP=ecl
+
+install:
+  - if [ -x ./install.sh ] && head -2 ./install.sh | grep '^# cl-travis' > /dev/null;
+    then
+      ./install.sh;
+    else
+      curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | sh;
+    fi
+
+script:
+  - cl -e '(in-package :cl-user)'
+       -e "(ql:quickload '(prove let-over-lambda))"
+       -e '(setf prove:*debug-on-error* t)'
+       -e '(setf *debugger-hook*
+                 (lambda (c h)
+                   (declare (ignore c h))
+                   (uiop:quit -1)))'
+       -e '(or (prove:run :let-over-lambda-test)
+               (uiop:quit -1))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,7 @@ env:
     - LISP=ecl
 
 install:
-  - if [ -x ./install.sh ] && head -2 ./install.sh | grep '^# cl-travis' > /dev/null;
-    then
-      ./install.sh;
-    else
-      curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | sh;
-    fi
+  - curl -L https://github.com/luismbo/cl-travis/raw/master/install.sh | sh
 
 script:
   - cl -e '(in-package :cl-user)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: common-lisp
 
 env:
   matrix:
-    - LISP=allego
+    - LISP=allegro
     - LISP=sbcl
     - LISP=ccl
     - LISP=clisp

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,12 @@ env:
     - LISP=ecl
 
 install:
-  - curl -L https://github.com/luismbo/cl-travis/raw/master/install.sh | sh
+  - if [ -x ./install.sh ] && head -2 ./install.sh | grep '^# cl-travis' > /dev/null;
+    then
+      ./install.sh;
+    else
+      curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | sh;
+    fi
 
 script:
   - cl -e '(in-package :cl-user)'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # let-over-lambda
 
-[https://travis-ci.org/EuAndreh/let-over-lambda.svg?branch=master]
+[](https://travis-ci.org/EuAndreh/let-over-lambda.svg?branch=master)
 
 Doug Hoyte's "Production" version of macros from Let Over Lambda, ready for ASDF and Quicklisp.
 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,6 @@ Make sure you have the latest Quicklisp distribution, then include it as a depen
 
 (A B C D E F G H I J K)
 ```
+
+### Contributors
+- [André Miranda](https://github.com/EuAndreh/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # let-over-lambda
 
-[https://travis-ci.org/EuAndreh/let-over-lambda.svg?branch=master](https://travis-ci.org/EuAndreh/let-over-lambda)
+
+[https://travis-ci.org/EuAndreh/let-over-lambda](https://travis-ci.org/EuAndreh/let-over-lambda.svg?branch=master)
 
 Doug Hoyte's "Production" version of macros from Let Over Lambda, ready for ASDF and Quicklisp.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # let-over-lambda
 
+[https://travis-ci.org/EuAndreh/let-over-lambda.svg?branch=master]
+
 Doug Hoyte's "Production" version of macros from Let Over Lambda, ready for ASDF and Quicklisp.
 
 Read more about the book and code at: http://letoverlambda.com

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # let-over-lambda
 
-
-[https://travis-ci.org/EuAndreh/let-over-lambda](https://travis-ci.org/EuAndreh/let-over-lambda.svg?branch=master)
+[https://travis-ci.org/EuAndreh/let-over-lambda.svg?branch=master](https://travis-ci.org/EuAndreh/let-over-lambda)
 
 Doug Hoyte's "Production" version of macros from Let Over Lambda, ready for ASDF and Quicklisp.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # let-over-lambda
 
-![https://travis-ci.org/EuAndreh/let-over-lambda.svg?branch=master](https://travis-ci.org/EuAndreh/let-over-lambda)
+[![Build Status](https://travis-ci.org/EuAndreh/let-over-lambda.svg?branch=master)](https://travis-ci.org/EuAndreh/let-over-lambda)
 
 Doug Hoyte's "Production" version of macros from Let Over Lambda, ready for ASDF and Quicklisp.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # let-over-lambda
 
-[https://travis-ci.org/EuAndreh/let-over-lambda.svg?branch=master](https://travis-ci.org/EuAndreh/let-over-lambda)
+![https://travis-ci.org/EuAndreh/let-over-lambda.svg?branch=master](https://travis-ci.org/EuAndreh/let-over-lambda)
 
 Doug Hoyte's "Production" version of macros from Let Over Lambda, ready for ASDF and Quicklisp.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # let-over-lambda
 
-[](https://travis-ci.org/EuAndreh/let-over-lambda.svg?branch=master)
+[https://travis-ci.org/EuAndreh/let-over-lambda.svg?branch=master](https://travis-ci.org/EuAndreh/let-over-lambda)
 
 Doug Hoyte's "Production" version of macros from Let Over Lambda, ready for ASDF and Quicklisp.
 

--- a/let-over-lambda-test.asd
+++ b/let-over-lambda-test.asd
@@ -1,0 +1,24 @@
+;;;; -*- Mode: LISP; Syntax: COMMON-LISP; Package: LET-OVER-LAMBDA; Base: 10 -*- file: let-over-lambda.asd
+
+(in-package :cl-user)
+
+(defpackage let-over-lambda-test-asd
+  (:use :cl :asdf))
+
+(in-package :let-over-lambda-test-asd)
+
+(defsystem #:let-over-lambda-test
+  :serial t
+  :description "The test code for Let Over Lambda."
+  :version #.*lol-version*
+  :license "BSD Simplified"
+  :depends-on (#:let-over-lambda
+               #:prove)
+  :components ((:module "t"
+                :components
+                ((:test-file "let-over-lambda"))))
+
+  :defsystem-depends-on (prove-asdf)
+  :perform (test-op :after (op c)
+                    (funcall (intern #.(string :run-test-system) :prove-asdf) c)
+                    (asdf:clear-system c)))

--- a/let-over-lambda-test.asd
+++ b/let-over-lambda-test.asd
@@ -10,10 +10,10 @@
 (defsystem #:let-over-lambda-test
   :serial t
   :description "The test code for Let Over Lambda."
-  :version #.*lol-version*
   :license "BSD Simplified"
   :depends-on (#:let-over-lambda
-               #:prove)
+               #:prove
+               #:named-readtables)
   :components ((:module "t"
                 :components
                 ((:test-file "let-over-lambda"))))
@@ -22,3 +22,5 @@
   :perform (test-op :after (op c)
                     (funcall (intern #.(string :run-test-system) :prove-asdf) c)
                     (asdf:clear-system c)))
+
+;; EOF

--- a/let-over-lambda.asd
+++ b/let-over-lambda.asd
@@ -20,7 +20,7 @@
   :maintainer "\"the Phoeron\" Colin J.E. Lupton <sysop@thephoeron.com>"
   :license "BSD Simplified"
   :depends-on (#:cl-ppcre
-               #:cl-syntax)
+               #:named-readtables)
   :components ((:file "package")
                (:file "let-over-lambda")))
 

--- a/let-over-lambda.asd
+++ b/let-over-lambda.asd
@@ -19,7 +19,8 @@
   :author "Doug Hoyte <doug@hoytech.com>"
   :maintainer "\"the Phoeron\" Colin J.E. Lupton <sysop@thephoeron.com>"
   :license "BSD Simplified"
-  :depends-on (#:cl-ppcre)
+  :depends-on (#:cl-ppcre
+               #:cl-syntax)
   :components ((:file "package")
                (:file "let-over-lambda")))
 

--- a/let-over-lambda.lisp
+++ b/let-over-lambda.lisp
@@ -285,6 +285,25 @@
 
 (in-readtable lol-syntax)
 
+(defmacro! nlet-tail (n letargs &body body)
+  (let ((gs (loop for i in letargs
+               collect (gensym))))
+    `(macrolet
+         ((,n ,gs
+            `(progn
+               (psetq
+                ,@(apply #'nconc
+                         (mapcar
+                          #'list
+                          ',(mapcar #'car letargs)
+                          (list ,@gs))))
+               (go ,',g!n))))
+       (block ,g!b
+         (let ,letargs
+           (tagbody
+              ,g!n (return-from
+                    ,g!b (progn ,@body))))))))
+
 (defmacro alet% (letargs &rest body)
   `(let ((this) ,@letargs)
      (setq this ,@(last body))

--- a/let-over-lambda.lisp
+++ b/let-over-lambda.lisp
@@ -273,7 +273,7 @@
     `(declare (optimize (speed ,numarg)
                         (safety ,(- 3 numarg)))))
 
-  (defsyntax lol-syntax
+  (defreadtable lol-syntax
     (:merge :standard)
     (:dispatch-macro-char #\# #\" #'|#"-reader|)
     (:dispatch-macro-char #\# #\> #'|#>-reader|)
@@ -283,7 +283,7 @@
     (:dispatch-macro-char #\# #\` #'|#`-reader|)
     (:dispatch-macro-char #\# #\f #'|#f-reader|)))
 
-(use-syntax lol-syntax)
+(in-readtable lol-syntax)
 
 (defmacro alet% (letargs &rest body)
   `(let ((this) ,@letargs)

--- a/let-over-lambda.lisp
+++ b/let-over-lambda.lisp
@@ -110,75 +110,75 @@
           ,(progn ,@body)))))
 
 ;; Nestable suggestion from Daniel Herring
-(defun |#"-reader| (stream sub-char numarg)
-  (declare (ignore sub-char numarg))
-  (let (chars (state 'normal) (depth 1))
-    (loop do
-      (let ((curr (read-char stream)))
-        (cond ((eq state 'normal)
-                 (cond ((char= curr #\#)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+ (defun |#"-reader| (stream sub-char numarg)
+   (declare (ignore sub-char numarg))
+   (let (chars (state 'normal) (depth 1))
+     (loop do
+          (let ((curr (read-char stream)))
+            (cond ((eq state 'normal)
+                   (cond ((char= curr #\#)
                           (push #\# chars)
                           (setq state 'read-sharp))
-                       ((char= curr #\")
+                         ((char= curr #\")
                           (setq state 'read-quote))
-                       (t
+                         (t
                           (push curr chars))))
-              ((eq state 'read-sharp)
-                 (cond ((char= curr #\")
+                  ((eq state 'read-sharp)
+                   (cond ((char= curr #\")
                           (push #\" chars)
                           (incf depth)
                           (setq state 'normal))
-                       (t
+                         (t
                           (push curr chars)
                           (setq state 'normal))))
-              ((eq state 'read-quote)
-                 (cond ((char= curr #\#)
+                  ((eq state 'read-quote)
+                   (cond ((char= curr #\#)
                           (decf depth)
                           (if (zerop depth) (return))
                           (push #\" chars)
                           (push #\# chars)
                           (setq state 'normal))
-                       (t
+                         (t
                           (push #\" chars)
                           (if (char= curr #\")
-                            (setq state 'read-quote)
-                            (progn
-                              (push curr chars)
-                              (setq state 'normal)))))))))
-   (coerce (nreverse chars) 'string)))
+                              (setq state 'read-quote)
+                              (progn
+                                (push curr chars)
+                                (setq state 'normal)))))))))
+     (coerce (nreverse chars) 'string))))
 
-(set-dispatch-macro-character
-  #\# #\" #'|#"-reader|)
+; (set-dispatch-macro-character #\# #\" #'|#"-reader|)
 
 ; This version is from Martin Dirichs
-(defun |#>-reader| (stream sub-char numarg)
-  (declare (ignore sub-char numarg))
-  (let (chars)
-    (do ((curr (read-char stream)
-               (read-char stream)))
-        ((char= #\newline curr))
-      (push curr chars))
-    (let ((pattern (nreverse chars))
-          output)
-      (labels ((match (pos chars)
-        (if (null chars)
-          pos
-          (if (char= (nth pos pattern) (car chars))
-              (match (1+ pos) (cdr chars))
-              (match 0 (cdr (append (subseq pattern 0 pos) chars)))))))
-        (do (curr
-             (pos 0))
-            ((= pos (length pattern)))
-          (setf curr (read-char stream)
-                pos (match pos (list curr)))
-          (push curr output))
-        (coerce
-          (nreverse
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defun |#>-reader| (stream sub-char numarg)
+    (declare (ignore sub-char numarg))
+    (let (chars)
+      (do ((curr (read-char stream)
+                 (read-char stream)))
+          ((char= #\newline curr))
+        (push curr chars))
+      (let ((pattern (nreverse chars))
+            output)
+        (labels ((match (pos chars)
+                   (if (null chars)
+                       pos
+                       (if (char= (nth pos pattern) (car chars))
+                           (match (1+ pos) (cdr chars))
+                           (match 0 (cdr (append (subseq pattern 0 pos) chars)))))))
+          (do (curr
+               (pos 0))
+              ((= pos (length pattern)))
+            (setf curr (read-char stream)
+                  pos (match pos (list curr)))
+            (push curr output))
+          (coerce
+           (nreverse
             (nthcdr (length pattern) output))
-          'string)))))
+           'string))))))
 
-(set-dispatch-macro-character
-  #\# #\> #'|#>-reader|)
+; (set-dispatch-macro-character #\# #\> #'|#>-reader|)
 
 (defun segment-reader (stream ch n)
   (if (> n 0)
@@ -208,29 +208,29 @@
        ,(cadr ,g!args))))
 
 #+cl-ppcre
-(defun |#~-reader| (stream sub-char numarg)
-  (declare (ignore sub-char numarg))
-  (let ((mode-char (read-char stream)))
-    (cond
-      ((char= mode-char #\m)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defun |#~-reader| (stream sub-char numarg)
+    (declare (ignore sub-char numarg))
+    (let ((mode-char (read-char stream)))
+      (cond
+        ((char= mode-char #\m)
          (match-mode-ppcre-lambda-form
-           (segment-reader stream
-                           (read-char stream)
-                           1)
-           (coerce (loop for c = (read-char stream)
-                         while (alpha-char-p c)
-                         collect c
-                         finally (unread-char c stream))
-                   'string)))
-      ((char= mode-char #\s)
+          (segment-reader stream
+                          (read-char stream)
+                          1)
+          (coerce (loop for c = (read-char stream)
+                     while (alpha-char-p c)
+                     collect c
+                     finally (unread-char c stream))
+                  'string)))
+        ((char= mode-char #\s)
          (subst-mode-ppcre-lambda-form
-           (segment-reader stream
-                           (read-char stream)
-                           2)))
-      (t (error "Unknown #~~ mode character")))))
+          (segment-reader stream
+                          (read-char stream)
+                          2)))
+        (t (error "Unknown #~~ mode character"))))))
 
-#+cl-ppcre
-(set-dispatch-macro-character #\# #\~ #'|#~-reader|)
+; #+cl-ppcre (set-dispatch-macro-character #\# #\~ #'|#~-reader|)
 
 (defmacro! dlambda (&rest ds)
   `(lambda (&rest ,g!args)
@@ -257,16 +257,33 @@
      (if it ,then ,else)))
 
 (eval-when (:compile-toplevel :execute :load-toplevel)
-    (defun |#`-reader| (stream sub-char numarg)
-      (declare (ignore sub-char))
-      (unless numarg (setq numarg 1))
-      `(lambda ,(loop for i from 1 to numarg
-                      collect (symb 'a i))
-         ,(funcall
-            (get-macro-character #\`) stream nil)))
+  (defun |#`-reader| (stream sub-char numarg)
+    (declare (ignore sub-char))
+    (unless numarg (setq numarg 1))
+    `(lambda ,(loop for i from 1 to numarg
+                 collect (symb 'a i))
+       ,(funcall
+         (get-macro-character #\`) stream nil)))
 
-    (set-dispatch-macro-character
-      #\# #\` #'|#`-reader|))
+  (defun |#f-reader| (stream sub-char numarg)
+    (declare (ignore stream sub-char))
+    (setq numarg (or numarg 3))
+    (unless (<= numarg 3)
+      (error "Bad value for #f: ~a" numarg))
+    `(declare (optimize (speed ,numarg)
+                        (safety ,(- 3 numarg)))))
+
+  (defsyntax lol-syntax
+    (:merge :standard)
+    (:dispatch-macro-char #\# #\" #'|#"-reader|)
+    (:dispatch-macro-char #\# #\> #'|#>-reader|)
+    #+cl-ppcre
+    (:dispatch-macro-char #\# #\~ #'|#~-reader|)
+    (:dispatch-macro-char #\# #\` #'|#`-reader|)
+    (:dispatch-macro-char #\# #\` #'|#`-reader|)
+    (:dispatch-macro-char #\# #\f #'|#f-reader|)))
+
+(use-syntax lol-syntax)
 
 (defmacro alet% (letargs &rest body)
   `(let ((this) ,@letargs)
@@ -375,15 +392,7 @@
               ,,expr))))
 
 ;; Chapter 7
-(eval-when (:compile-toplevel :execute :load-toplevel)
-    (set-dispatch-macro-character #\# #\f
-       (lambda (stream sub-char numarg)
-         (declare (ignore stream sub-char))
-         (setq numarg (or numarg 3))
-         (unless (<= numarg 3)
-           (error "Bad value for #f: ~a" numarg))
-         `(declare (optimize (speed ,numarg)
-                             (safety ,(- 3 numarg)))))))
+
 
 (defmacro fast-progn (&rest body)
   `(locally #f ,@body))

--- a/let-over-lambda.lisp
+++ b/let-over-lambda.lisp
@@ -280,7 +280,6 @@
     #+cl-ppcre
     (:dispatch-macro-char #\# #\~ #'|#~-reader|)
     (:dispatch-macro-char #\# #\` #'|#`-reader|)
-    (:dispatch-macro-char #\# #\` #'|#`-reader|)
     (:dispatch-macro-char #\# #\f #'|#f-reader|)))
 
 (in-readtable lol-syntax)

--- a/package.lisp
+++ b/package.lisp
@@ -3,9 +3,9 @@
 (defpackage #:let-over-lambda
   (:nicknames #:lol)
   (:use #:cl #:cl-user #:cl-ppcre)
-  (:import-from #:cl-syntax
-                #:defsyntax
-                #:use-syntax)
+  (:import-from #:named-readtables
+                #:defreadtable
+                #:in-readtable)
   (:export #:lol-syntax
            #:mkstr
            #:symb

--- a/package.lisp
+++ b/package.lisp
@@ -27,6 +27,7 @@
            #:alambda
            #:aif
            #:|#`-reader|
+           #:|#f-reader|
            #:nlet-tail
            #:alet%
            #:alet

--- a/package.lisp
+++ b/package.lisp
@@ -27,6 +27,7 @@
            #:alambda
            #:aif
            #:|#`-reader|
+           #:nlet-tail
            #:alet%
            #:alet
            #:let-binding-transform

--- a/package.lisp
+++ b/package.lisp
@@ -3,7 +3,11 @@
 (defpackage #:let-over-lambda
   (:nicknames #:lol)
   (:use #:cl #:cl-user #:cl-ppcre)
-  (:export #:mkstr
+  (:import-from #:cl-syntax
+                #:defsyntax
+                #:use-syntax)
+  (:export #:lol-syntax
+           #:mkstr
            #:symb
            #:group
            #:flatten

--- a/t/let-over-lambda.lisp
+++ b/t/let-over-lambda.lisp
@@ -43,9 +43,9 @@ the reading of this string is..."
 
 (deftest read-anaphor-sharp-backquote-test
   (is '#`((,a1))
-      '(lambda (a1) `((,a1))
-        :test #'equalp)
-      "SHARP-BACKQUOTE expands correctly.")
+      '(lambda (a1) `((,a1)))
+      "SHARP-BACKQUOTE expands correctly."
+      :test #'equalp)
   (is-expand #.(#3`(((,@a2)) ,a3 (,a1 ,a1))
                 (gensym)
                 '(a b c)

--- a/t/let-over-lambda.lisp
+++ b/t/let-over-lambda.lisp
@@ -63,4 +63,5 @@ the reading of this string is..."
       '((declare (optimize (speed 1) (safety 2)))
         (declare (optimize (speed 2) (safety 1))))
       "SHARP-F correctly expands into rarely used compiler options."))
+
 (run-test-all)

--- a/t/let-over-lambda.lisp
+++ b/t/let-over-lambda.lisp
@@ -1,0 +1,6 @@
+(in-package cl-user)
+(defpackage let-over-lambda-test
+  (:use cl let-over-lambda prove))
+(in-package let-over-lambda-test)
+
+;; NOTE: To run this test file, execute `(asdf:test-system :let-over-lambda)' in your Lisp.

--- a/t/let-over-lambda.lisp
+++ b/t/let-over-lambda.lisp
@@ -9,11 +9,11 @@
 ;; NOTE: To run this test file, execute `(asdf:test-system :let-over-lambda)' in your Lisp.
 
 (plan 5)
-#|
- (deftest |test-#""#-read-macro|
+
+(deftest |test-#""#-read-macro|
   (is  #"Contains " and \."#
    "Contains \" and \\." "SHARP-QUOTE read macro works as expected."   ))
-|#
+
 (defparameter heredoc-string #>END
 I can put anything here: ", , "# and ># are
 no problem. The only thing that will terminate

--- a/t/let-over-lambda.lisp
+++ b/t/let-over-lambda.lisp
@@ -43,7 +43,8 @@ the reading of this string is..."
 
 (deftest read-anaphor-sharp-backquote-test
   (is '#`((,a1))
-      '(lambda (a1) `((,a1)))
+      '(lambda (a1) `((,a1))
+        :test #'equalp)
       "SHARP-BACKQUOTE expands correctly.")
   (is-expand #.(#3`(((,@a2)) ,a3 (,a1 ,a1))
                 (gensym)

--- a/t/let-over-lambda.lisp
+++ b/t/let-over-lambda.lisp
@@ -1,6 +1,66 @@
 (in-package cl-user)
 (defpackage let-over-lambda-test
-  (:use cl let-over-lambda prove))
+  (:use cl let-over-lambda prove)
+  (:import-from named-readtables
+                in-readtable))
 (in-package let-over-lambda-test)
+(in-readtable lol-syntax)
 
 ;; NOTE: To run this test file, execute `(asdf:test-system :let-over-lambda)' in your Lisp.
+
+(plan 5)
+#|
+ (deftest |test-#""#-read-macro|
+  (is  #"Contains " and \."#
+   "Contains \" and \\." "SHARP-QUOTE read macro works as expected."   ))
+|#
+(defparameter heredoc-string #>END
+I can put anything here: ", , "# and ># are
+no problem. The only thing that will terminate
+the reading of this string is...END)
+
+(deftest heredoc-read-macro-test
+  (is heredoc-string
+      "I can put anything here: \", , \"# and ># are
+no problem. The only thing that will terminate
+the reading of this string is..."
+      "SHARP-GREATER-THEN read macro works as expected."))
+
+(deftest pilfered-perl-regex-syntax-test
+  (is-expand '#~m|\w+tp://|
+             '(lambda ($str) (cl-ppcre:scan "\\w+tp://" $str))
+             "#~m expands correctly.")
+  (is-expand '#~s/abc/def/
+             '(lambda ($str) (cl-ppcre:regex-replace-all "abc" $str "def"))
+             "#~s expands correctly.")
+  (is-values (#~m/abc/ "123abc")
+             '(3 6 #() #())
+             "#~m runs correctly."
+             :test #'equalp)
+  (is (#~s/abc/def/ "Testing abc testing abc")
+      "Testing def testing def"
+      "#~s runs correctly."))
+
+(deftest read-anaphor-sharp-backquote-test
+  (is '#`((,a1))
+      '(lambda (a1) `((,a1)))
+      "SHARP-BACKQUOTE expands correctly.")
+  (is-expand #.(#3`(((,@a2)) ,a3 (,a1 ,a1))
+                (gensym)
+                '(a b c)
+                'hello)
+             (((a b c)) hello ($g $g))
+             "SHARP-BACKQUOTE runs correctly, respecting order, gensyms, nesting, numarg, etc."))
+
+(deftest sharp-f-test
+  (is '#f
+      '(declare (optimize (speed 3) (safety 0)))
+      "Default numarg SHARP-F expands correctly.")
+  (is '#0f
+      '(declare (optimize (speed 0) (safety 3)))
+      "Numarg = 3 SHARP-F expands correctly.")
+  (is '(#1f #2f)
+      '((declare (optimize (speed 1) (safety 2)))
+        (declare (optimize (speed 2) (safety 1))))
+      "SHARP-F correctly expands into rarely used compiler options."))
+(run-test-all)


### PR DESCRIPTION
Added support for cl-syntax.

Although is adds a little bit of complexity to the book's code, it also makes it more portable: loading it doesn't change your readtable, and you can handle read-macros like symbols in a package.

Added an `(eval-when (:compile-toplevel :load-toplevel :execute) ...)` to all read-macro-reading function.

Put the code for the `#f` reader a bit before, before the code stars using the `sharp-backquote` read-macro.

I know it diverges a bit from the book, but makes the `production version` title be more real.