### PR TITLE
Split files, add dependencies and remove copied/duplicate code

### DIFF
--- a/let-over-lambda.asd
+++ b/let-over-lambda.asd
@@ -23,7 +23,8 @@
                #:named-readtables
                #:on-lisp
                #:defmacro-enhance
-               #:cl-reexport)
+               #:cl-reexport
+               #:cl-heredoc)
   :components ((:file "readtable")
                (:file "package")
                (:file "let-over-lambda")))

--- a/let-over-lambda.asd
+++ b/let-over-lambda.asd
@@ -20,8 +20,12 @@
   :maintainer "\"the Phoeron\" Colin J.E. Lupton <sysop@thephoeron.com>"
   :license "BSD Simplified"
   :depends-on (#:cl-ppcre
-               #:named-readtables)
-  :components ((:file "package")
+               #:named-readtables
+               #:on-lisp
+               #:defmacro-enhance
+               #:cl-reexport)
+  :components ((:file "readtable")
+               (:file "package")
                (:file "let-over-lambda")))
 
 ;; EOF

--- a/let-over-lambda.asd
+++ b/let-over-lambda.asd
@@ -20,7 +20,7 @@
   :maintainer "\"the Phoeron\" Colin J.E. Lupton <sysop@thephoeron.com>"
   :license "BSD Simplified"
   :depends-on (#:cl-ppcre
-               #:cl-syntax)
+               #:named-readtables)
   :components ((:file "package")
                (:file "let-over-lambda")))
 

--- a/let-over-lambda.asd
+++ b/let-over-lambda.asd
@@ -19,7 +19,8 @@
   :author "Doug Hoyte <doug@hoytech.com>"
   :maintainer "\"the Phoeron\" Colin J.E. Lupton <sysop@thephoeron.com>"
   :license "BSD Simplified"
-  :depends-on (#:cl-ppcre)
+  :depends-on (#:cl-ppcre
+               #:cl-syntax)
   :components ((:file "package")
                (:file "let-over-lambda")))
 

--- a/let-over-lambda.lisp
+++ b/let-over-lambda.lisp
@@ -1,7 +1,5 @@
 ;;;; -*- Mode: LISP; Syntax: COMMON-LISP; Package: LET-OVER-LAMBDA; Base: 10 -*- file: let-over-lambda.lisp
 
-(in-package #:let-over-lambda)
-
 ;; Antiweb (C) Doug Hoyte
 
 ;; This is a "production" version of LOL with bug-fixes
@@ -29,212 +27,13 @@
 ;; - Cheap hacks to support new Backquote implementation in SBCL v1.2.2
 
 ;; Safety feature for SBCL>=v1.2.2
-#+sbcl
-(eval-when (:compile-toplevel :execute)
-  (handler-case
-      (progn
-        (sb-ext:assert-version->= 1 2 2)
-        (setq *features* (remove 'old-sbcl *features*)))
-    (error ()
-      (pushnew 'old-sbcl *features*))))
 
-(defun group (source n)
-  (if (zerop n) (error "zero length"))
-  (labels ((rec (source acc)
-             (let ((rest (nthcdr n source)))
-               (if (consp rest)
-                   (rec rest (cons
-                               (subseq source 0 n)
-                               acc))
-                   (nreverse
-                     (cons source acc))))))
-    (if source (rec source nil) nil)))
-
-(eval-when (:compile-toplevel :execute :load-toplevel)
-  (defun mkstr (&rest args)
-    (with-output-to-string (s)
-      (dolist (a args) (princ a s))))
-
-  (defun symb (&rest args)
-    (values (intern (apply #'mkstr args))))
-
-  (defun flatten (x)
-    (labels ((rec (x acc)
-                  (cond ((null x) acc)
-                        #+(and sbcl (not lol::old-sbcl))
-                        ((typep x 'sb-impl::comma) (rec (sb-impl::comma-expr x) acc))
-                        ((atom x) (cons x acc))
-                        (t (rec
-                             (car x)
-                             (rec (cdr x) acc))))))
-      (rec x nil)))
-
-  (defun g!-symbol-p (s)
-    (and (symbolp s)
-         (> (length (symbol-name s)) 2)
-         (string= (symbol-name s)
-                  "G!"
-                  :start1 0
-                  :end1 2)))
-
-  (defun o!-symbol-p (s)
-    (and (symbolp s)
-         (> (length (symbol-name s)) 2)
-         (string= (symbol-name s)
-                  "O!"
-                  :start1 0
-                  :end1 2)))
-
-  (defun o!-symbol-to-g!-symbol (s)
-    (symb "G!"
-          (subseq (symbol-name s) 2))))
-
-(defmacro defmacro/g! (name args &rest body)
-  (let ((syms (remove-duplicates
-               (remove-if-not #'g!-symbol-p
-                              (flatten body)))))
-    `(defmacro ,name ,args
-       (let ,(mapcar
-              (lambda (s)
-                `(,s (gensym ,(subseq
-                               (symbol-name s)
-                               2))))
-              syms)
-         ,@body))))
-
-(defmacro defmacro! (name args &rest body)
-  (let* ((os (remove-if-not #'o!-symbol-p args))
-         (gs (mapcar #'o!-symbol-to-g!-symbol os)))
-    `(defmacro/g! ,name ,args
-       `(let ,(mapcar #'list (list ,@gs) (list ,@os))
-          ,(progn ,@body)))))
-
-;; Nestable suggestion from Daniel Herring
-(eval-when (:compile-toplevel :load-toplevel :execute)
- (defun |#"-reader| (stream sub-char numarg)
-   (declare (ignore sub-char numarg))
-   (let (chars (state 'normal) (depth 1))
-     (loop do
-          (let ((curr (read-char stream)))
-            (cond ((eq state 'normal)
-                   (cond ((char= curr #\#)
-                          (push #\# chars)
-                          (setq state 'read-sharp))
-                         ((char= curr #\")
-                          (setq state 'read-quote))
-                         (t
-                          (push curr chars))))
-                  ((eq state 'read-sharp)
-                   (cond ((char= curr #\")
-                          (push #\" chars)
-                          (incf depth)
-                          (setq state 'normal))
-                         (t
-                          (push curr chars)
-                          (setq state 'normal))))
-                  ((eq state 'read-quote)
-                   (cond ((char= curr #\#)
-                          (decf depth)
-                          (if (zerop depth) (return))
-                          (push #\" chars)
-                          (push #\# chars)
-                          (setq state 'normal))
-                         (t
-                          (push #\" chars)
-                          (if (char= curr #\")
-                              (setq state 'read-quote)
-                              (progn
-                                (push curr chars)
-                                (setq state 'normal)))))))))
-     (coerce (nreverse chars) 'string))))
-
-; (set-dispatch-macro-character #\# #\" #'|#"-reader|)
-
-; This version is from Martin Dirichs
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (defun |#>-reader| (stream sub-char numarg)
-    (declare (ignore sub-char numarg))
-    (let (chars)
-      (do ((curr (read-char stream)
-                 (read-char stream)))
-          ((char= #\newline curr))
-        (push curr chars))
-      (let ((pattern (nreverse chars))
-            output)
-        (labels ((match (pos chars)
-                   (if (null chars)
-                       pos
-                       (if (char= (nth pos pattern) (car chars))
-                           (match (1+ pos) (cdr chars))
-                           (match 0 (cdr (append (subseq pattern 0 pos) chars)))))))
-          (do (curr
-               (pos 0))
-              ((= pos (length pattern)))
-            (setf curr (read-char stream)
-                  pos (match pos (list curr)))
-            (push curr output))
-          (coerce
-           (nreverse
-            (nthcdr (length pattern) output))
-           'string))))))
-
-; (set-dispatch-macro-character #\# #\> #'|#>-reader|)
-
-(defun segment-reader (stream ch n)
-  (if (> n 0)
-    (let ((chars))
-      (do ((curr (read-char stream)
-                 (read-char stream)))
-          ((char= ch curr))
-        (push curr chars))
-      (cons (coerce (nreverse chars) 'string)
-            (segment-reader stream ch (- n 1))))))
-
-#+cl-ppcre
-(defmacro! match-mode-ppcre-lambda-form (o!args o!mods)
- ``(lambda (,',g!str)
-     (cl-ppcre:scan
-       ,(if (zerop (length ,g!mods))
-          (car ,g!args)
-          (format nil "(?~a)~a" ,g!mods (car ,g!args)))
-       ,',g!str)))
-
-#+cl-ppcre
-(defmacro! subst-mode-ppcre-lambda-form (o!args)
- ``(lambda (,',g!str)
-     (cl-ppcre:regex-replace-all
-       ,(car ,g!args)
-       ,',g!str
-       ,(cadr ,g!args))))
-
-#+cl-ppcre
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (defun |#~-reader| (stream sub-char numarg)
-    (declare (ignore sub-char numarg))
-    (let ((mode-char (read-char stream)))
-      (cond
-        ((char= mode-char #\m)
-         (match-mode-ppcre-lambda-form
-          (segment-reader stream
-                          (read-char stream)
-                          1)
-          (coerce (loop for c = (read-char stream)
-                     while (alpha-char-p c)
-                     collect c
-                     finally (unread-char c stream))
-                  'string)))
-        ((char= mode-char #\s)
-         (subst-mode-ppcre-lambda-form
-          (segment-reader stream
-                          (read-char stream)
-                          2)))
-        (t (error "Unknown #~~ mode character"))))))
-
-; #+cl-ppcre (set-dispatch-macro-character #\# #\~ #'|#~-reader|)
+(in-package let-over-lambda)
+(in-readtable lol.rt:lol-syntax)
 
 (defmacro! dlambda (&rest ds)
-  `(lambda (&rest ,g!args)
-     (case (car ,g!args)
+  `(lambda (&rest ,g!-args)
+     (case (car ,g!-args)
        ,@(mapcar
            (lambda (d)
              `(,(if (eq t (car d))
@@ -242,48 +41,9 @@
                   (list (car d)))
                (apply (lambda ,@(cdr d))
                       ,(if (eq t (car d))
-                         g!args
-                         `(cdr ,g!args)))))
+                         g!-args
+                         `(cdr ,g!-args)))))
            ds))))
-
-;; Graham's alambda
-(defmacro alambda (parms &body body)
-  `(labels ((self ,parms ,@body))
-     #'self))
-
-;; Graham's aif
-(defmacro aif (test then &optional else)
-  `(let ((it ,test))
-     (if it ,then ,else)))
-
-(eval-when (:compile-toplevel :execute :load-toplevel)
-  (defun |#`-reader| (stream sub-char numarg)
-    (declare (ignore sub-char))
-    (unless numarg (setq numarg 1))
-    `(lambda ,(loop for i from 1 to numarg
-                 collect (symb 'a i))
-       ,(funcall
-         (get-macro-character #\`) stream nil)))
-
-  (defun |#f-reader| (stream sub-char numarg)
-    (declare (ignore stream sub-char))
-    (setq numarg (or numarg 3))
-    (unless (<= numarg 3)
-      (error "Bad value for #f: ~a" numarg))
-    `(declare (optimize (speed ,numarg)
-                        (safety ,(- 3 numarg)))))
-
-  (defreadtable lol-syntax
-    (:merge :standard)
-    (:dispatch-macro-char #\# #\" #'|#"-reader|)
-    (:dispatch-macro-char #\# #\> #'|#>-reader|)
-    #+cl-ppcre
-    (:dispatch-macro-char #\# #\~ #'|#~-reader|)
-    (:dispatch-macro-char #\# #\` #'|#`-reader|)
-    (:dispatch-macro-char #\# #\` #'|#`-reader|)
-    (:dispatch-macro-char #\# #\f #'|#f-reader|)))
-
-(in-readtable lol-syntax)
 
 (defmacro alet% (letargs &rest body)
   `(let ((this) ,@letargs)
@@ -353,11 +113,11 @@
      ,val))
 
 (defmacro with-pandoric (syms box &rest body)
-  (let ((g!box (gensym "box")))
-    `(let ((,g!box ,box))
-       (declare (ignorable ,g!box))
+  (let ((g!-box (gensym "box")))
+    `(let ((,g!-box ,box))
+       (declare (ignorable ,g!-box))
        (symbol-macrolet
-         (,@(mapcar #`(,a1 (get-pandoric ,g!box ',a1))
+         (,@(mapcar #`(,a1 (get-pandoric ,g!-box ',a1))
                     syms))
          ,@body))))
 
@@ -410,10 +170,10 @@
     (if stream
       `(funcall (formatter ,fmt)
          ,stream ,@args)
-      (let ((g!stream (gensym "stream")))
-        `(with-output-to-string (,g!stream)
+      (let ((g!-stream (gensym "stream")))
+        `(with-output-to-string (,g!-stream)
            (funcall (formatter ,fmt)
-             ,g!stream ,@args))))
+             ,g!-stream ,@args))))
     form))
 
 (declaim (inline make-tlist tlist-left
@@ -479,15 +239,14 @@
   (if places
     `(tagbody
        ,@(mapcar
-           #`(let ((,g!a #1=,(nth (car a1) places))
-                   (,g!b #2=,(nth (cadr a1) places)))
-               (if (,comparator ,g!b ,g!a)
-                 (setf #1# ,g!b
-                       #2# ,g!a)))
+           #`(let ((,g!-a #1=,(nth (car a1) places))
+                   (,g!-b #2=,(nth (cadr a1) places)))
+               (if (,comparator ,g!-b ,g!-a)
+                 (setf #1# ,g!-b
+                       #2# ,g!-a)))
            (build-batcher-sn (length places))))))
 
 ;;;;;; NEW CODE FOR ANTIWEB
-#+cl-ppcre
 (defun dollar-symbol-p (s)
   (and (symbolp s)
        (> (length (symbol-name s)) 1)
@@ -508,23 +267,24 @@
 
 ;; WARNING: Not %100 correct. Removes forms like (... if-match ...) from the
 ;; sub-lexical scope even though this isn't an invocation of the macro.
-#+cl-ppcre
-(defmacro! if-match ((test str) conseq &optional altern)
+(defmacro! if-match ((test o!-str) conseq &optional altern)
   (let ((dollars (remove-duplicates
-                   (remove-if-not #'dollar-symbol-p
-                                  (flatten (prune-if-match-bodies-from-sub-lexical-scope conseq))))))
+                   (remove-if-not
+                    #'dollar-symbol-p
+                    (flatten
+                     (prune-if-match-bodies-from-sub-lexical-scope conseq))))))
     (let ((top (or (car (sort (mapcar #'dollar-symbol-p dollars) #'>)) 0)))
-      `(let ((,g!str ,str))
-         (multiple-value-bind (,g!s ,g!e ,g!ms ,g!me) (,test ,g!str)
-           (declare (ignorable ,g!e ,g!me))
-           (if ,g!s
-             (if (< (length ,g!ms) ,top)
-               (error "ifmatch: too few matches")
-               (let ,(mapcar #`(,(symb "$" a1) (subseq ,g!str (aref ,g!ms ,(1- a1))
-                                                              (aref ,g!me ,(1- a1))))
-                             (loop for i from 1 to top collect i))
-                 ,conseq))
-              ,altern))))))
+      `(multiple-value-bind (,g!-s ,g!-e ,g!-ms ,g!-me) (,test ,o!-str)
+        (declare (ignorable ,g!-e ,g!-me))
+        (if ,g!-s
+            (if (< (length ,g!-ms) ,top)
+                (error "ifmatch: too few matches")
+                (let ,(mapcar #`(,(symb "$" a1) (subseq ,o!-str
+                                                        (aref ,g!-ms ,(1- a1))
+                                                        (aref ,g!-me ,(1- a1))))
+                              (loop for i from 1 to top collect i))
+                  ,conseq))
+            ,altern)))))
 
 (defmacro when-match ((test str) conseq &rest more-conseq)
   `(if-match (,test ,str)

--- a/let-over-lambda.lisp
+++ b/let-over-lambda.lisp
@@ -272,8 +272,6 @@
                    ,conseq))
              ,altern)))))
 
-(defmacro when-match ((test str) conseq &rest more-conseq)
+(defmacro when-match ((test str) &body forms)
   `(if-match (,test ,str)
-     (progn ,conseq ,@more-conseq)))
-
-;; EOF
+     (progn ,@forms)))

--- a/let-over-lambda.lisp
+++ b/let-over-lambda.lisp
@@ -45,12 +45,6 @@
                          `(cdr ,g!-args)))))
            ds))))
 
-(defmacro alet% (letargs &rest body)
-  `(let ((this) ,@letargs)
-     (setq this ,@(last body))
-     ,@(butlast body)
-     this))
-
 (defmacro alet (letargs &rest body)
   `(let ((this) ,@letargs)
      (setq this ,@(last body))
@@ -151,9 +145,6 @@
               ,',vars pandoric-eval-tunnel
               ,,expr))))
 
-;; Chapter 7
-
-
 (defmacro fast-progn (&rest body)
   `(locally #f ,@body))
 
@@ -246,7 +237,6 @@
                        #2# ,g!-a)))
            (build-batcher-sn (length places))))))
 
-;;;;;; NEW CODE FOR ANTIWEB
 (defun dollar-symbol-p (s)
   (and (symbolp s)
        (> (length (symbol-name s)) 1)

--- a/let-over-lambda.lisp
+++ b/let-over-lambda.lisp
@@ -252,10 +252,15 @@
     (let ((top (or (car (sort (mapcar #'dollar-symbol-p dollars) #'>))
                    0)))
       `(multiple-value-bind (,g!-match ,g!-matched-registers) (,test ,o!-str)
-         (declare (ignorable , g!-match))
          (if ,g!-match
              (if (< (length ,g!-matched-registers) ,top)
-                 (error "ifmatch: too few matches")
+                 (error ,(concatenate
+                         'string
+                         "IF-MATCH: too few matches. There is(are) "
+                         (write-to-string top)
+                         " matched register(s) but only ~a match(es) was(were) found in ~s.")
+                        (length ,g!-matched-registers)
+                        ,g!-matched-registers)
                  (let ,(mapcar #`(,( symb "$" a1) (aref ,g!-matched-registers
                                                         ,(1- a1)))
                                (loop for i from 1 to top collect i))

--- a/let-over-lambda.lisp
+++ b/let-over-lambda.lisp
@@ -273,7 +273,7 @@
     `(declare (optimize (speed ,numarg)
                         (safety ,(- 3 numarg)))))
 
-  (defsyntax lol-syntax
+  (defreadtable lol-syntax
     (:merge :standard)
     (:dispatch-macro-char #\# #\" #'|#"-reader|)
     (:dispatch-macro-char #\# #\> #'|#>-reader|)
@@ -283,7 +283,7 @@
     (:dispatch-macro-char #\# #\` #'|#`-reader|)
     (:dispatch-macro-char #\# #\f #'|#f-reader|)))
 
-(use-syntax lol-syntax)
+(in-readtable lol-syntax)
 
 (defmacro alet% (letargs &rest body)
   `(let ((this) ,@letargs)

--- a/let-over-lambda.lisp
+++ b/let-over-lambda.lisp
@@ -110,75 +110,75 @@
           ,(progn ,@body)))))
 
 ;; Nestable suggestion from Daniel Herring
-(defun |#"-reader| (stream sub-char numarg)
-  (declare (ignore sub-char numarg))
-  (let (chars (state 'normal) (depth 1))
-    (loop do
-      (let ((curr (read-char stream)))
-        (cond ((eq state 'normal)
-                 (cond ((char= curr #\#)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+ (defun |#"-reader| (stream sub-char numarg)
+   (declare (ignore sub-char numarg))
+   (let (chars (state 'normal) (depth 1))
+     (loop do
+          (let ((curr (read-char stream)))
+            (cond ((eq state 'normal)
+                   (cond ((char= curr #\#)
                           (push #\# chars)
                           (setq state 'read-sharp))
-                       ((char= curr #\")
+                         ((char= curr #\")
                           (setq state 'read-quote))
-                       (t
+                         (t
                           (push curr chars))))
-              ((eq state 'read-sharp)
-                 (cond ((char= curr #\")
+                  ((eq state 'read-sharp)
+                   (cond ((char= curr #\")
                           (push #\" chars)
                           (incf depth)
                           (setq state 'normal))
-                       (t
+                         (t
                           (push curr chars)
                           (setq state 'normal))))
-              ((eq state 'read-quote)
-                 (cond ((char= curr #\#)
+                  ((eq state 'read-quote)
+                   (cond ((char= curr #\#)
                           (decf depth)
                           (if (zerop depth) (return))
                           (push #\" chars)
                           (push #\# chars)
                           (setq state 'normal))
-                       (t
+                         (t
                           (push #\" chars)
                           (if (char= curr #\")
-                            (setq state 'read-quote)
-                            (progn
-                              (push curr chars)
-                              (setq state 'normal)))))))))
-   (coerce (nreverse chars) 'string)))
+                              (setq state 'read-quote)
+                              (progn
+                                (push curr chars)
+                                (setq state 'normal)))))))))
+     (coerce (nreverse chars) 'string))))
 
-(set-dispatch-macro-character
-  #\# #\" #'|#"-reader|)
+; (set-dispatch-macro-character #\# #\" #'|#"-reader|)
 
 ; This version is from Martin Dirichs
-(defun |#>-reader| (stream sub-char numarg)
-  (declare (ignore sub-char numarg))
-  (let (chars)
-    (do ((curr (read-char stream)
-               (read-char stream)))
-        ((char= #\newline curr))
-      (push curr chars))
-    (let ((pattern (nreverse chars))
-          output)
-      (labels ((match (pos chars)
-        (if (null chars)
-          pos
-          (if (char= (nth pos pattern) (car chars))
-              (match (1+ pos) (cdr chars))
-              (match 0 (cdr (append (subseq pattern 0 pos) chars)))))))
-        (do (curr
-             (pos 0))
-            ((= pos (length pattern)))
-          (setf curr (read-char stream)
-                pos (match pos (list curr)))
-          (push curr output))
-        (coerce
-          (nreverse
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defun |#>-reader| (stream sub-char numarg)
+    (declare (ignore sub-char numarg))
+    (let (chars)
+      (do ((curr (read-char stream)
+                 (read-char stream)))
+          ((char= #\newline curr))
+        (push curr chars))
+      (let ((pattern (nreverse chars))
+            output)
+        (labels ((match (pos chars)
+                   (if (null chars)
+                       pos
+                       (if (char= (nth pos pattern) (car chars))
+                           (match (1+ pos) (cdr chars))
+                           (match 0 (cdr (append (subseq pattern 0 pos) chars)))))))
+          (do (curr
+               (pos 0))
+              ((= pos (length pattern)))
+            (setf curr (read-char stream)
+                  pos (match pos (list curr)))
+            (push curr output))
+          (coerce
+           (nreverse
             (nthcdr (length pattern) output))
-          'string)))))
+           'string))))))
 
-(set-dispatch-macro-character
-  #\# #\> #'|#>-reader|)
+; (set-dispatch-macro-character #\# #\> #'|#>-reader|)
 
 (defun segment-reader (stream ch n)
   (if (> n 0)
@@ -208,29 +208,29 @@
        ,(cadr ,g!args))))
 
 #+cl-ppcre
-(defun |#~-reader| (stream sub-char numarg)
-  (declare (ignore sub-char numarg))
-  (let ((mode-char (read-char stream)))
-    (cond
-      ((char= mode-char #\m)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defun |#~-reader| (stream sub-char numarg)
+    (declare (ignore sub-char numarg))
+    (let ((mode-char (read-char stream)))
+      (cond
+        ((char= mode-char #\m)
          (match-mode-ppcre-lambda-form
-           (segment-reader stream
-                           (read-char stream)
-                           1)
-           (coerce (loop for c = (read-char stream)
-                         while (alpha-char-p c)
-                         collect c
-                         finally (unread-char c stream))
-                   'string)))
-      ((char= mode-char #\s)
+          (segment-reader stream
+                          (read-char stream)
+                          1)
+          (coerce (loop for c = (read-char stream)
+                     while (alpha-char-p c)
+                     collect c
+                     finally (unread-char c stream))
+                  'string)))
+        ((char= mode-char #\s)
          (subst-mode-ppcre-lambda-form
-           (segment-reader stream
-                           (read-char stream)
-                           2)))
-      (t (error "Unknown #~~ mode character")))))
+          (segment-reader stream
+                          (read-char stream)
+                          2)))
+        (t (error "Unknown #~~ mode character"))))))
 
-#+cl-ppcre
-(set-dispatch-macro-character #\# #\~ #'|#~-reader|)
+; #+cl-ppcre (set-dispatch-macro-character #\# #\~ #'|#~-reader|)
 
 (defmacro! dlambda (&rest ds)
   `(lambda (&rest ,g!args)
@@ -257,16 +257,33 @@
      (if it ,then ,else)))
 
 (eval-when (:compile-toplevel :execute :load-toplevel)
-    (defun |#`-reader| (stream sub-char numarg)
-      (declare (ignore sub-char))
-      (unless numarg (setq numarg 1))
-      `(lambda ,(loop for i from 1 to numarg
-                      collect (symb 'a i))
-         ,(funcall
-            (get-macro-character #\`) stream nil)))
+  (defun |#`-reader| (stream sub-char numarg)
+    (declare (ignore sub-char))
+    (unless numarg (setq numarg 1))
+    `(lambda ,(loop for i from 1 to numarg
+                 collect (symb 'a i))
+       ,(funcall
+         (get-macro-character #\`) stream nil)))
 
-    (set-dispatch-macro-character
-      #\# #\` #'|#`-reader|))
+  (defun |#f-reader| (stream sub-char numarg)
+    (declare (ignore stream sub-char))
+    (setq numarg (or numarg 3))
+    (unless (<= numarg 3)
+      (error "Bad value for #f: ~a" numarg))
+    `(declare (optimize (speed ,numarg)
+                        (safety ,(- 3 numarg)))))
+
+  (defsyntax lol-syntax
+    (:merge :standard)
+    (:dispatch-macro-char #\# #\" #'|#"-reader|)
+    (:dispatch-macro-char #\# #\> #'|#>-reader|)
+    #+cl-ppcre
+    (:dispatch-macro-char #\# #\~ #'|#~-reader|)
+    (:dispatch-macro-char #\# #\` #'|#`-reader|)
+    (:dispatch-macro-char #\# #\` #'|#`-reader|)
+    (:dispatch-macro-char #\# #\f #'|#f-reader|)))
+
+(use-syntax lol-syntax)
 
 (defmacro alet% (letargs &rest body)
   `(let ((this) ,@letargs)
@@ -375,15 +392,7 @@
               ,,expr))))
 
 ;; Chapter 7
-(eval-when (:compile-toplevel :execute :load-toplevel)
-    (set-dispatch-macro-character #\# #\f
-       (lambda (stream sub-char numarg)
-         (declare (ignore stream sub-char))
-         (setq numarg (or numarg 3))
-         (unless (<= numarg 3)
-           (error "Bad value for #f: ~a" numarg))
-         `(declare (optimize (speed ,numarg)
-                             (safety ,(- 3 numarg)))))))
+
 
 (defmacro fast-progn (&rest body)
   `(locally #f ,@body))

--- a/package.lisp
+++ b/package.lisp
@@ -3,9 +3,9 @@
 (defpackage #:let-over-lambda
   (:nicknames #:lol)
   (:use #:cl #:cl-user #:cl-ppcre)
-  (:import-from #:cl-syntax
-                #:defsyntax
-                #:use-syntax)
+  (:import-from #:named-readtables
+                #:defreadtable
+                #:in-readtable)
   (:export #:lol-syntax
            #:mkstr
            #:symb

--- a/package.lisp
+++ b/package.lisp
@@ -11,12 +11,7 @@
                 #:flatten)
   (:import-from #:defmacro-enhance
                 #:defmacro!)
-  (:export #:fact
-           #:choose
-           #:dlambda
-           #:alambda
-           #:aif
-           #:alet%
+  (:export #:dlambda
            #:alet
            #:let-binding-transform
            #:pandoriclet
@@ -42,10 +37,7 @@
            #:build-batcher-sn
            #:sortf
            #:dollar-symbol-p
-           #:prune-if-match-bodies-from-sub-lexical-scope
            #:if-match
            #:when-match))
 
 (cl-reexport:reexport-from :lol.rt)
-
-;; EOF

--- a/package.lisp
+++ b/package.lisp
@@ -6,27 +6,16 @@
   (:import-from #:named-readtables
                 #:defreadtable
                 #:in-readtable)
-  (:export #:lol-syntax
-           #:mkstr
-           #:symb
-           #:group
-           #:flatten
-           #:fact
+  (:import-from #:on-lisp
+                #:symb
+                #:flatten)
+  (:import-from #:defmacro-enhance
+                #:defmacro!)
+  (:export #:fact
            #:choose
-           #:g!-symbol-p
-           #:defmacro/g!
-           #:o!-symbol-p
-           #:o!-symbol-to-g!-symbol
-           #:defmacro!
-           #:|#"-reader|
-           #:segment-reader
-           #:match-mode-ppcre-lambda-form
-           #:subst-mode-ppcre-lambda-form
-           #:|#~-reader|
            #:dlambda
            #:alambda
            #:aif
-           #:|#`-reader|
            #:alet%
            #:alet
            #:let-binding-transform
@@ -56,5 +45,7 @@
            #:prune-if-match-bodies-from-sub-lexical-scope
            #:if-match
            #:when-match))
+
+(cl-reexport:reexport-from :lol.rt)
 
 ;; EOF

--- a/package.lisp
+++ b/package.lisp
@@ -40,4 +40,6 @@
            #:if-match
            #:when-match))
 
+(in-package #:let-over-lambda)
+
 (cl-reexport:reexport-from :lol.rt)

--- a/package.lisp
+++ b/package.lisp
@@ -3,7 +3,11 @@
 (defpackage #:let-over-lambda
   (:nicknames #:lol)
   (:use #:cl #:cl-user #:cl-ppcre)
-  (:export #:mkstr
+  (:import-from #:cl-syntax
+                #:defsyntax
+                #:use-syntax)
+  (:export #:lol-syntax
+           #:mkstr
            #:symb
            #:group
            #:flatten

--- a/readtable.lisp
+++ b/readtable.lisp
@@ -1,0 +1,126 @@
+(defpackage let-over-lambda.readtable
+  (:use cl)
+  (:nicknames lol.rt)
+  (:import-from defmacro-enhance
+                defmacro!)
+  (:import-from named-readtables
+                defreadtable)
+  (:import-from on-lisp
+                symb)
+  (:export lol-syntax
+           |#"-reader|
+           segment-reader
+           match-mode-ppcre-lambda-form
+           subst-mode-ppcre-lambda-form
+           |#~-reader|
+           |#`-reader|
+           |#f-reader|))
+(in-package lol.rt)
+
+;; Nestable suggestion from Daniel Herring
+(defun |#"-reader| (stream sub-char numarg)
+  (declare (ignore sub-char numarg))
+  (let (chars (state 'normal) (depth 1))
+    (loop do
+         (let ((curr (read-char stream)))
+           (cond ((eq state 'normal)
+                  (cond ((char= curr #\#)
+                         (push #\# chars)
+                         (setq state 'read-sharp))
+                        ((char= curr #\")
+                         (setq state 'read-quote))
+                        (t
+                         (push curr chars))))
+                 ((eq state 'read-sharp)
+                  (cond ((char= curr #\")
+                         (push #\" chars)
+                         (incf depth)
+                         (setq state 'normal))
+                        (t
+                         (push curr chars)
+                         (setq state 'normal))))
+                 ((eq state 'read-quote)
+                  (cond ((char= curr #\#)
+                         (decf depth)
+                         (if (zerop depth) (return))
+                         (push #\" chars)
+                         (push #\# chars)
+                         (setq state 'normal))
+                        (t
+                         (push #\" chars)
+                         (if (char= curr #\")
+                             (setq state 'read-quote)
+                             (progn
+                               (push curr chars)
+                               (setq state 'normal)))))))))
+    (coerce (nreverse chars) 'string)))
+
+(defun segment-reader (stream ch n)
+  (if (> n 0)
+    (let ((chars))
+      (do ((curr (read-char stream)
+                 (read-char stream)))
+          ((char= ch curr))
+        (push curr chars))
+      (cons (coerce (nreverse chars) 'string)
+            (segment-reader stream ch (- n 1))))))
+
+(defmacro! match-mode-ppcre-lambda-form (o!-args o!-mods)
+ ``(lambda (,',g!-str)
+     (cl-ppcre:scan
+       ,(if (zerop (length ,o!-mods))
+          (car ,o!-args)
+          (format nil "(?~a)~a" ,o!-mods (car ,o!-args)))
+       ,',g!-str)))
+
+(defmacro! subst-mode-ppcre-lambda-form (o!-args)
+ ``(lambda (,',g!-str)
+     (cl-ppcre:regex-replace-all
+       ,(car ,o!-args)
+       ,',g!-str
+       ,(cadr ,o!-args))))
+
+(defun |#~-reader| (stream sub-char numarg)
+  (declare (ignore sub-char numarg))
+  (let ((mode-char (read-char stream)))
+    (cond
+      ((char= mode-char #\m)
+       (match-mode-ppcre-lambda-form
+        (segment-reader stream
+                        (read-char stream)
+                        1)
+        (coerce (loop for c = (read-char stream)
+                   while (alpha-char-p c)
+                   collect c
+                   finally (unread-char c stream))
+                'string)))
+      ((char= mode-char #\s)
+       (subst-mode-ppcre-lambda-form
+        (segment-reader stream
+                        (read-char stream)
+                        2)))
+      (t (error "Unknown #~~ mode character")))))
+
+(defun |#`-reader| (stream sub-char numarg)
+  (declare (ignore sub-char))
+  (unless numarg (setq numarg 1))
+  `(lambda ,(loop for i from 1 to numarg
+               collect (symb 'a i))
+     ,(funcall
+       (get-macro-character #\`) stream nil)))
+
+(defun |#f-reader| (stream sub-char numarg)
+  (declare (ignore stream sub-char))
+  (setq numarg (or numarg 3))
+  (unless (<= numarg 3)
+    (error "Bad value for #f: ~a" numarg))
+  `(declare (optimize (speed ,numarg)
+                      (safety ,(- 3 numarg)))))
+
+(defreadtable lol-syntax
+  (:merge :standard)
+  (:dispatch-macro-char #\# #\" #'|#"-reader|)
+  (:dispatch-macro-char #\# #\~ #'|#~-reader|)
+  (:dispatch-macro-char #\# #\` #'|#`-reader|)
+  (:dispatch-macro-char #\# #\` #'|#`-reader|)
+  (:dispatch-macro-char #\# #\f #'|#f-reader|))

--- a/readtable.lisp
+++ b/readtable.lisp
@@ -80,6 +80,14 @@
        ,',g!-str
        ,(cadr ,o!-args))))
 
+(defparameter *matching-delimiters*
+  '((#\( . #\)) (#\[ . #\]) (#\{ . #\}) (#\< . #\>)))
+
+(defun get-pair (char)
+  (or (car (rassoc char *matching-delimiters*))
+      (cdr (assoc char *matching-delimiters*))
+      char))
+
 (defun |#~-reader| (stream sub-char numarg)
   (declare (ignore sub-char numarg))
   (let ((mode-char (read-char stream)))
@@ -87,7 +95,7 @@
       ((char= mode-char #\m)
        (match-mode-ppcre-lambda-form
         (segment-reader stream
-                        (read-char stream)
+                        (get-pair (read-char stream))
                         1)
         (coerce (loop for c = (read-char stream)
                    while (alpha-char-p c)

--- a/readtable.lisp
+++ b/readtable.lisp
@@ -120,6 +120,7 @@
 (defreadtable lol-syntax
   (:merge :standard)
   (:dispatch-macro-char #\# #\" #'|#"-reader|)
+  (:dispatch-macro-char #\# #\> #'cl-heredoc:read-heredoc)
   (:dispatch-macro-char #\# #\~ #'|#~-reader|)
   (:dispatch-macro-char #\# #\` #'|#`-reader|)
   (:dispatch-macro-char #\# #\` #'|#`-reader|)

--- a/readtable.lisp
+++ b/readtable.lisp
@@ -67,7 +67,7 @@
 
 (defmacro! match-mode-ppcre-lambda-form (o!-args o!-mods)
  ``(lambda (,',g!-str)
-     (CL-PPCRE:all-matches-as-strings
+     (ppcre:scan-to-strings
        ,(if (zerop (length ,o!-mods))
           (car ,o!-args)
           (format nil "(?~a)~a" ,o!-mods (car ,o!-args)))
@@ -75,7 +75,7 @@
 
 (defmacro! subst-mode-ppcre-lambda-form (o!-args)
  ``(lambda (,',g!-str)
-     (cl-ppcre:regex-replace-all
+     (ppcre:regex-replace-all
        ,(car ,o!-args)
        ,',g!-str
        ,(cadr ,o!-args))))

--- a/readtable.lisp
+++ b/readtable.lisp
@@ -80,12 +80,12 @@
        ,',g!-str
        ,(cadr ,o!-args))))
 
-(defparameter *matching-delimiters*
+(defparameter matching-delimiters
   '((#\( . #\)) (#\[ . #\]) (#\{ . #\}) (#\< . #\>)))
 
 (defun get-pair (char)
-  (or (car (rassoc char *matching-delimiters*))
-      (cdr (assoc char *matching-delimiters*))
+  (or (car (rassoc char matching-delimiters))
+      (cdr (assoc char matching-delimiters))
       char))
 
 (defun |#~-reader| (stream sub-char numarg)

--- a/readtable.lisp
+++ b/readtable.lisp
@@ -67,7 +67,7 @@
 
 (defmacro! match-mode-ppcre-lambda-form (o!-args o!-mods)
  ``(lambda (,',g!-str)
-     (cl-ppcre:scan
+     (CL-PPCRE:all-matches-as-strings
        ,(if (zerop (length ,o!-mods))
           (car ,o!-args)
           (format nil "(?~a)~a" ,o!-mods (car ,o!-args)))


### PR DESCRIPTION
This was a bigger refactor of the code.
Changes:
1. Removed `defmacro!` related code: imported code from [defmacro-enhance](https://github.com/mabragor/defmacro-enhance/), which took the code from the book, and made a more portable version of the code-walking. It is actively maintained and used by [many projects](http://quickdocs.org/defmacro-enhance/). There's a difference in usage (as described in the `defmacro-enhance`'s README): `g!symbols` becomes `g!-symbols`, and `o!symbols` don't map to `g!symbols`: `o!symbols` becomes `o!-symbols` and map to `o!-symbols`;
2. Code from Paul Graham's On Lisp (like `symb` or `flatten`) was removed and imported from the [source](https://github.com/DalekBaldwin/on-lisp);
3. Removed the `#>` reader-macro: changed to [cl-heredoc](https://github.com/e-user/cl-heredoc) (as described in the [errata](http://letoverlambda.com/index.cl/errata));
4. Kept the [named-readtables](http://common-lisp.net/project/named-readtables/) support;
5. Added the file `readtable.lisp`, with all the read-macro related stuff, with a package called `let-over-lambda.readtable` (with a nickname of `lol.rt`);
6. Added the line `(cl-reexport:reexport-from :lol.rt)` at the end of the `package.lisp` file: it uses the [cl-reexport](https://github.com/takagi/cl-reexport) package and reexports from the `lol` package all symbols from `lol.rt`. That way, one can `(:import-from :let-over-lambda ...)` without having to know if the symbol is in the `lol` package or in the `lol.rt` package;
7. Improved the `#~` reader-macro: added support for Perl-like balanced regex delimiters. Ex: `(#~m<abc> ...)`. Matching delimiters inserted are in `matching-delimiters`;
8. Changed the frunction called from the `#~m` reader-macro: instead of `ppcre:scan`, now it call `ppcre:scan-to-strings` as it was found to be more practical in daily usage;
9. Changed `if-macro`: it allow nesting and binds `$n` local variables accordingly.

TODO:
1. Wait for the [on-lisp](https://github.com/DalekBaldwin/on-lisp) package to become available in Quicklisp (I already created an [issue](https://github.com/DalekBaldwin/on-lisp/issues/1), and hope that @DalekBaldwin will agree);
2. Add some tests and check implementation independence (I can do it). Maybe add some examples from the book and put many corner cases to check compatibility with the code from the book (it can be done easily with [Travis CI](http://travis-ci.org));
3. Update the README, explaining the API and adding links to the code in the site (I can do it too =p );
4. Add docstrings to functions and macros (And this too =p );
5. Test the `if-match` macro (I can try it)