### PR TITLE
Added support for docstring in DEFMACRO!

### DIFF
--- a/let-over-lambda.lisp
+++ b/let-over-lambda.lisp
@@ -90,10 +90,15 @@
           (subseq (symbol-name s) 2))))
 
 (defmacro defmacro/g! (name args &rest body)
-  (let ((syms (remove-duplicates
-               (remove-if-not #'g!-symbol-p
-                              (flatten body)))))
+  (let* ((syms (remove-duplicates
+                (remove-if-not #'g!-symbol-p
+                               (flatten body))))
+         (docstring (car body))
+         (body (if (stringp docstring)
+                   (cdr body)
+                   body)))
     `(defmacro ,name ,args
+       ,docstring
        (let ,(mapcar
               (lambda (s)
                 `(,s (gensym ,(subseq
@@ -104,8 +109,13 @@
 
 (defmacro defmacro! (name args &rest body)
   (let* ((os (remove-if-not #'o!-symbol-p args))
-         (gs (mapcar #'o!-symbol-to-g!-symbol os)))
+         (gs (mapcar #'o!-symbol-to-g!-symbol os))
+         (docstring (car body))
+         (body (if (stringp docstring)
+                   (cdr body)
+                   body)))
     `(defmacro/g! ,name ,args
+       ,docstring
        `(let ,(mapcar #'list (list ,@gs) (list ,@os))
           ,(progn ,@body)))))
 

--- a/let-over-lambda.lisp
+++ b/let-over-lambda.lisp
@@ -93,7 +93,9 @@
   (let* ((syms (remove-duplicates
                 (remove-if-not #'g!-symbol-p
                                (flatten body))))
-         (docstring (car body))
+         (docstring (if (stringp (car body))
+                        (car body)
+                        nil))
          (body (if (stringp docstring)
                    (cdr body)
                    body)))
@@ -110,7 +112,9 @@
 (defmacro defmacro! (name args &rest body)
   (let* ((os (remove-if-not #'o!-symbol-p args))
          (gs (mapcar #'o!-symbol-to-g!-symbol os))
-         (docstring (car body))
+         (docstring (if (stringp (car body))
+                        (car body)
+                        nil))
          (body (if (stringp docstring)
                    (cdr body)
                    body)))


### PR DESCRIPTION
Add support for `docstring` in a `defmacro!` form.

Before:
```lisp
* (defmacro! docstring-test ()
    "my docstring"
    '(my form))
DOCSTRING-TEST

* (documentation * 'function)
NIL
```

Now:
```lisp
* (defmacro! docstring-test ()
    "my docstring"
    '(my form))
DOCSTRING-TEST

* (documentation * 'function)
"my docstring"
```