### PR TITLE
Change from ppcre:scan to ppcre:scan-to-strings

### DIFF
--- a/let-over-lambda.lisp
+++ b/let-over-lambda.lisp
@@ -207,7 +207,7 @@
 #+cl-ppcre
 (defmacro! match-mode-ppcre-lambda-form (o!args o!mods)
  ``(lambda (,',g!str)
-     (cl-ppcre:scan
+     (ppcre:scan-to-strings
        ,(if (zerop (length ,g!mods))
           (car ,g!args)
           (format nil "(?~a)~a" ,g!mods (car ,g!args)))

--- a/t/let-over-lambda.lisp
+++ b/t/let-over-lambda.lisp
@@ -37,13 +37,13 @@ the reading of this string is..."
 
 (deftest pilfered-perl-regex-syntax-test
   (is-expand '#~m|\w+tp://|
-             '(lambda ($str) (cl-ppcre:scan "\\w+tp://" $str))
+             '(lambda ($str) (cl-ppcre:scan-to-strings "\\w+tp://" $str))
              "#~m expands correctly.")
   (is-expand '#~s/abc/def/
              '(lambda ($str) (cl-ppcre:regex-replace-all "abc" $str "def"))
              "#~s expands correctly.")
   (is-values (#~m/abc/ "123abc")
-             '(3 6 #() #())
+             '("abc" #())
              "#~m runs correctly."
              :test #'equalp)
   (is (#~s/abc/def/ "Testing abc testing abc")


### PR DESCRIPTION
`ppcre:scan-to-strings` gives a more practical usage to the `#~m` macro, as far as _pilfering_ Perl's syntax goes.